### PR TITLE
ensure github actions worker is always unregistred

### DIFF
--- a/.github/workflows/build_rhel_bootc.yml
+++ b/.github/workflows/build_rhel_bootc.yml
@@ -76,6 +76,7 @@ jobs:
           registry: ${{ env.PUSHREGISTRY }}
 
       - name: Clean up the subscription
+        if: always()
         env:
           SMDEV_CONTAINER_OFF: 1
         run: subscription-manager unregister


### PR DESCRIPTION
This closes a gap where registrations could be left dangling