### PR TITLE
Update RHEL version and target var better

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 
-FROM registry.redhat.io/rhel9/rhel-bootc:9.5
+FROM registry.redhat.io/rhel9/rhel-bootc:9.6
 
 #install software
 RUN dnf -y install tmux mkpasswd
@@ -25,7 +25,7 @@ echo "Welcome to the bootc-http instance!" > /usr/share/www/html/index.html
 EORUN
 
 #clean up caches in the image and lint the container
-RUN rm /var/{cache,lib}/* -rf
+RUN rm /var/{cache,lib}/dnf /var/lib/rhsm /var/cache/ldconfig -rf
 RUN bootc container lint
 
 EXPOSE 80


### PR DESCRIPTION
The example should target build artifacts in var a little better, removing everything can result in non-working KVM environments, etc.

I looked into the example to find the dnf and rhsm locations we most likely want to remove

Also bumped the RHEL 9 minor